### PR TITLE
Added markdownify

### DIFF
--- a/website/_data/quake-articles.yml
+++ b/website/_data/quake-articles.yml
@@ -1,4 +1,4 @@
-- title: "What Do Your Ideas Want From You?"
+- title: What Do Your Ideas Want From You?
   url: https://bewrong.substack.com/p/what-do-ideas-want
   author: Judah
 - title: "Are you serious?"

--- a/website/_data/tools.yml
+++ b/website/_data/tools.yml
@@ -37,4 +37,4 @@
 - title: JSON Crack
   url: https://jsoncrack.com/
   author: Aykut Saraç
-  note: Seamlessly visualize your JSON data instantly into graphs. <a href="https://editor.herowand.com/">Herowand Editor</a> visualizes JSON, YAML, XML, TOML and CSV 
+  note: Seamlessly visualizes your JSON data instantly into graphs. [Herowand Editor](https://editor.herowand.com/) visualizes JSON, YAML, XML, TOML and CSV 

--- a/website/_includes/introductions.html
+++ b/website/_includes/introductions.html
@@ -1,12 +1,12 @@
 {% for topic in include.introductions %}
 <span style="font-weight:bold">{{topic.name}}</span><br>
     {% if topic.note %}
-    <span class="collections-note">{{topic.note}}</span><br>
+    <span class="collections-note">{{topic.note | markdownify | remove: '<p>' | remove: '</p>' }}</span><br>
     {% endif %}
     {% for item in topic.items %}
     <span><a href="{{item.url}}">{{item.title}}</a>{% if item.author %} — {{item.author}} {% endif %}</span><br>
         {% if item.note %}
-        <span class="collections-note">{{item.note}}</span><br>
+        <span class="collections-note">{{item.note | markdownify | remove: '<p>' | remove: '</p>' }}</span><br>
         {% endif %}
     {% endfor %}
     <br>

--- a/website/_includes/reading-list.html
+++ b/website/_includes/reading-list.html
@@ -7,7 +7,7 @@
     <br>
     {% endif %}
     {% if article.note %}
-    <span class="collections-note">{{article.note}}</span>
+    <span class="collections-note">{{article.note | markdownify | remove: '<p>' | remove: '</p>'  }}</span>
     {% endif %}
 </p>
 {% endfor %}

--- a/website/restaurants.markdown
+++ b/website/restaurants.markdown
@@ -11,7 +11,7 @@ title: Restaurants Recommendations
   <p><strong>Category:</strong> {{ restaurant.category }}</p>
   <p><strong>Address:</strong> {{ restaurant.address }}</p>
   {% if restaurant.note %}
-  <p><strong>Note:</strong> {{ restaurant.note }}</p>
+  <p><strong>Note:</strong> {{ restaurant.note | | markdownify | remove: '<p>' | remove: '</p>' }}</p>
   {% endif %}
 </div>
 {% endfor %}


### PR DESCRIPTION
Markdownify fields from yaml data files. Markdownify wraps results in `<p>` and `</p>`. To get inline markdownify, we need to:
 ```
{{ 'markdown here' | markdownify | remove: '<p>' | remove: '</p>' }}
```

See:
https://github.com/jekyll/jekyll/issues/3571
https://github.com/jekyll/jekyll/issues/2248
