### PR TITLE
Resolve Gem Conflict

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
         }
     },
     "waitFor": "onCreateCommand",
-    "updateContentCommand": "cd website && gem update --system && bundle install",
+    "updateContentCommand": "cd website && gem update --system && bundle install && gem cleanup",
     "postCreateCommand": "echo \"alias nb='$(pwd)/.devcontainer/new_branch.sh'\" >> ~/.bashrc",
     "postAttachCommand": {
         "server": "cd website && jekyll serve"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,10 +21,10 @@
         }
     },
     "waitFor": "onCreateCommand",
-    "updateContentCommand": "cd website && gem update --system && bundle install && gem cleanup",
+    "updateContentCommand": "cd website && gem update --system && bundle install",
     "postCreateCommand": "echo \"alias nb='$(pwd)/.devcontainer/new_branch.sh'\" >> ~/.bashrc",
     "postAttachCommand": {
-        "server": "cd website && jekyll serve"
+        "server": "cd website && bundle exec jekyll serve"
     },
     "portsAttributes": {
         "4000": {


### PR DESCRIPTION
Solve this issue:

```
cd website && jekyll serve
@RamVasuthevan ➜ /workspaces/Personal-Website (main) $ cd website && jekyll serve
/usr/local/rvm/gems/ruby-3.2.2/gems/bundler-2.4.20/lib/bundler/runtime.rb:304:in `check_for_activated_spec!': You have already activated google-protobuf 3.25.1, but your Gemfile requires google-protobuf 3.25.0. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
        from /usr/local/rvm/gems/ruby-3.2.2/gems/bundler-2.4.20/lib/bundler/runtime.rb:25:in `block in setup'
        from /usr/local/rvm/gems/ruby-3.2.2/gems/bundler-2.4.20/lib/bundler/spec_set.rb:165:in `each'
        from /usr/local/rvm/gems/ruby-3.2.2/gems/bundler-2.4.20/lib/bundler/spec_set.rb:165:in `each'
        from /usr/local/rvm/gems/ruby-3.2.2/gems/bundler-2.4.20/lib/bundler/runtime.rb:24:in `map'
        from /usr/local/rvm/gems/ruby-3.2.2/gems/bundler-2.4.20/lib/bundler/runtime.rb:24:in `setup'
        from /usr/local/rvm/gems/ruby-3.2.2/gems/bundler-2.4.20/lib/bundler.rb:162:in `setup'
        from /usr/local/rvm/gems/ruby-3.2.2/gems/jekyll-4.3.2/lib/jekyll/plugin_manager.rb:52:in `require_from_bundler'
        from /usr/local/rvm/gems/ruby-3.2.2/gems/jekyll-4.3.2/exe/jekyll:11:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-3.2.2/bin/jekyll:32:in `load'
        from /usr/local/rvm/gems/ruby-3.2.2/bin/jekyll:32:in `<main>'
```