### PR TITLE
Add unpushed-commits commands to git notes

### DIFF
--- a/website/notes/git.md
+++ b/website/notes/git.md
@@ -30,3 +30,9 @@ title: git
         - `git config --global difftool.code.cmd 'code --wait --diff --reuse-window "$LOCAL" "$REMOTE"'` (Set code as a diff tool)
         - `git config --global diff.tool code` (Set code as the default diff tool)
         - `git config --global difftool.prompt false` (Disable the per file diff permission) 
+
+9. `git log @{u}..HEAD --oneline`
+    - Lists commits on the current branch that are not on its upstream. Useful for seeing unpushed commits. Works on any branch.
+
+10. `git cherry -v`
+    - Lists commits on the current branch that are not in the upstream branch. Uses patch-id comparison (not SHA), so it detects commits that have been cherry-picked or rebased into upstream with different SHAs. Marks `+` for not-in-upstream and `-` for patch-equivalent already in upstream.


### PR DESCRIPTION
Adds two new entries (#9 and #10) to `website/notes/git.md` covering commands for inspecting unpushed commits:

- **#9 `git log @{u}..HEAD --oneline`** — lists commits on the current branch not yet pushed to its upstream.
- **#10 `git cherry -v`** — lists commits not in the upstream branch using patch-id comparison, so it correctly handles cherry-picked or rebased commits with different SHAs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhjuAPGovsCLHDv4QgiA3t)_