### PR TITLE
Flatten VS Code difftool setup commands in git notes

### DIFF
--- a/website/notes/git.md
+++ b/website/notes/git.md
@@ -25,8 +25,14 @@ title: git
     - See diff for change between your brnach and main (two way)
 
 8. `git difftool --staged --tool=code`
-    - Opens the staged changes with the `code` diff tool 
-    - Needs to be setup with:
-        - `git config --global difftool.code.cmd 'code --wait --diff --reuse-window "$LOCAL" "$REMOTE"'` (Set code as a diff tool)
-        - `git config --global diff.tool code` (Set code as the default diff tool)
-        - `git config --global difftool.prompt false` (Disable the per file diff permission) 
+    - Opens the staged changes with the `code` diff tool
+    - Needs items 9–11 to be run once
+
+9. `git config --global difftool.code.cmd 'code --wait --diff --reuse-window "$LOCAL" "$REMOTE"'`
+    - Sets `code` as a diff tool
+
+10. `git config --global diff.tool code`
+    - Sets `code` as the default diff tool
+
+11. `git config --global difftool.prompt false`
+    - Disables the per-file diff permission prompt


### PR DESCRIPTION
## Summary
- Promotes the three `git config --global` difftool setup lines from nested sub-bullets under item 8 to their own top-level numbered items 9–11 in `website/notes/git.md`.
- Each setup command now starts at the left margin, so the `git config --global` prefix can't be accidentally dropped when copying a single line.

## Why
While following these notes today I accidentally pasted just `difftool.prompt false` (dropping the `git config --global` prefix), which fish then rejected as an unknown command. Flat numbered items make each command stand alone — harder to mis-copy.

## Test plan
- [ ] Visit the rendered page at `/notes/git.html` and confirm items 8–11 each render as top-level numbered entries.
- [ ] Copy each `git config --global …` line in turn and run in a fresh shell — confirm they all execute as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)