### PR TITLE
Add `git add --intent-to-add` tip to git notes

### DIFF
--- a/website/notes/git.md
+++ b/website/notes/git.md
@@ -30,3 +30,7 @@ title: git
         - `git config --global difftool.code.cmd 'code --wait --diff --reuse-window "$LOCAL" "$REMOTE"'` (Set code as a diff tool)
         - `git config --global diff.tool code` (Set code as the default diff tool)
         - `git config --global difftool.prompt false` (Disable the per file diff permission) 
+
+9. `git add --intent-to-add .` (or `git add -N .`)
+    - Marks untracked files as known to git without staging
+    - By default, untracked files don't show up in `git diff`


### PR DESCRIPTION
## Summary
- Adds bullet 9 to `website/notes/git.md` covering the `git add --intent-to-add` (`-N`) flag — marks untracked files as known to git without staging their content so they show up in `git diff`.

## Test plan
- [ ] Open `/notes/git.html` locally and confirm bullet 9 renders with the command formatted as code and both nested bullets visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)