### PR TITLE
Expand git notes: prune details and unpushed-commits entry

### DIFF
--- a/website/notes/git.md
+++ b/website/notes/git.md
@@ -3,42 +3,74 @@ layout: page
 title: git
 ---
 
-1. `git log --oneline`
-    - Lists all commits in the repository in a compact, one-line format
+## List Commits in a Compact Format
 
-2. `git commit --allow-empty -m "Empty commit"`
-    - Creates an empty commit with the message "Empty commit"
+`git log --oneline`
 
-3. `git commit --allow-empty --allow-empty-message -m ""`
-    - Creates an empty commit with an empty message. Creates an empty commit with an empty message. Useful for triggering CI pipelines and allowing for the creation of GitHub pull request
+Lists all commits in the repository in a compact, one-line format.
 
-4. `git reset --soft HEAD~1`
-    - Resets the current branch to the previous commit, keeping the changes in the staging area
+## Create an Empty Commit
 
-5. `git fetch --prune`
-    - Fetches from remote and removes stale remote-tracking refs (`origin/*` bookmarks) for branches deleted on the remote — local branches are never touched
-    - Prune without fetching: `git remote prune origin`
-    - After pruning, `git branch -vv` marks local branches whose remote is gone with `[origin/...: gone]` — usually means the PR was merged (squash merges hide this from `git branch -d`, so `-D` is needed)
-    - Make every fetch/pull auto-prune: `git config --global fetch.prune true`
+`git commit --allow-empty -m "Empty commit"`
 
-6. `git diff main..HEAD`
-    - See diff for changes on your branch but not on main (one way)
+Creates an empty commit with the message "Empty commit".
 
-7. `git diff main...HEAD`  
-    - See diff for change between your brnach and main (two way)
+## Create an Empty Commit with an Empty Message
 
-8. `git difftool --staged --tool=code`
-    - Opens the staged changes with the `code` diff tool 
-    - Needs to be setup with:
-        - `git config --global difftool.code.cmd 'code --wait --diff --reuse-window "$LOCAL" "$REMOTE"'` (Set code as a diff tool)
-        - `git config --global diff.tool code` (Set code as the default diff tool)
-        - `git config --global difftool.prompt false` (Disable the per file diff permission) 
+`git commit --allow-empty --allow-empty-message -m ""`
 
-9. `git add --intent-to-add .` (or `git add -N .`)
-    - Marks untracked files as known to git without staging
-    - By default, untracked files don't show up in `git diff`
+Useful for triggering CI pipelines and allowing for the creation of GitHub pull requests.
 
-10. `git log @{u}..HEAD --oneline`
-    - Lists unpushed commits: commits on the current branch that aren't on its upstream (`@{u}`)
-    - Branch-agnostic — works on any branch without hardcoding `main`
-    - Alternative: `git cherry -v` also detects patch-equivalent commits (`+` = unpushed, `-` = already upstream in some form)
+## Undo the Last Commit, Keeping Changes Staged
+
+`git reset --soft HEAD~1`
+
+Resets the current branch to the previous commit, keeping the changes in the staging area.
+
+## Remove Stale Remote-Tracking Refs
+
+`git fetch --prune`
+
+Fetches from remote and removes stale remote-tracking refs (`origin/*` bookmarks) for branches deleted on the remote. Local branches are never touched. To prune without fetching, use `git remote prune origin`.
+
+After pruning, `git branch -vv` marks local branches whose remote is gone with `[origin/...: gone]`. This usually means the PR was merged. Squash merges hide this from `git branch -d`, so `-D` is needed.
+
+To make every fetch and pull auto-prune:
+
+```bash
+git config --global fetch.prune true
+```
+
+## See Diff for Changes on Your Branch but Not on Main (One Way)
+
+`git diff main..HEAD`
+
+## See Diff for Changes Between Your Branch and Main (Two Way)
+
+`git diff main...HEAD`
+
+## Open Staged Changes in the VS Code Diff Tool
+
+`git difftool --staged --tool=code`
+
+Needs to be set up with:
+
+```bash
+git config --global difftool.code.cmd 'code --wait --diff --reuse-window "$LOCAL" "$REMOTE"' # Set code as a diff tool
+git config --global diff.tool code             # Set code as the default diff tool
+git config --global difftool.prompt false      # Disable the per file diff permission
+```
+
+## Mark Untracked Files as Known to Git Without Staging
+
+`git add --intent-to-add .` (or `git add -N .`)
+
+By default, untracked files don't show up in `git diff`.
+
+## List Unpushed Commits
+
+`git log @{u}..HEAD --oneline`
+
+Lists commits on the current branch that aren't on its upstream (`@{u}`). Branch-agnostic, so it works on any branch without hardcoding `main`.
+
+`git cherry -v` is an alternative that also detects patch-equivalent commits (`+` = unpushed, `-` = already upstream in some form).

--- a/website/notes/git.md
+++ b/website/notes/git.md
@@ -18,8 +18,6 @@ title: git
 5. `git fetch --prune`
     - Fetches from remote and removes stale remote-tracking refs (`origin/*` bookmarks) for branches deleted on the remote — local branches are never touched
     - Prune without fetching: `git remote prune origin`
-    - After pruning, `git branch -vv` marks local branches whose remote is gone with `[origin/...: gone]` — usually means the PR was merged (squash merges hide this from `git branch -d`, so `-D` is needed)
-    - Make every fetch/pull auto-prune: `git config --global fetch.prune true`
 
 6. `git diff main..HEAD`
     - See diff for changes on your branch but not on main (one way)

--- a/website/notes/git.md
+++ b/website/notes/git.md
@@ -16,7 +16,10 @@ title: git
     - Resets the current branch to the previous commit, keeping the changes in the staging area
 
 5. `git fetch --prune`
-    - Fetches from remote and removes any branches that have been deleted on the remote
+    - Fetches from remote and removes stale remote-tracking refs (`origin/*` bookmarks) for branches deleted on the remote — local branches are never touched
+    - Prune without fetching: `git remote prune origin`
+    - After pruning, `git branch -vv` marks local branches whose remote is gone with `[origin/...: gone]` — usually means the PR was merged (squash merges hide this from `git branch -d`, so `-D` is needed)
+    - Make every fetch/pull auto-prune: `git config --global fetch.prune true`
 
 6. `git diff main..HEAD`
     - See diff for changes on your branch but not on main (one way)
@@ -34,3 +37,8 @@ title: git
 9. `git add --intent-to-add .` (or `git add -N .`)
     - Marks untracked files as known to git without staging
     - By default, untracked files don't show up in `git diff`
+
+10. `git log @{u}..HEAD --oneline`
+    - Lists unpushed commits: commits on the current branch that aren't on its upstream (`@{u}`)
+    - Branch-agnostic — works on any branch without hardcoding `main`
+    - Alternative: `git cherry -v` also detects patch-equivalent commits (`+` = unpushed, `-` = already upstream in some form)

--- a/website/notes/git.md
+++ b/website/notes/git.md
@@ -3,74 +3,42 @@ layout: page
 title: git
 ---
 
-## List Commits in a Compact Format
+1. `git log --oneline`
+    - Lists all commits in the repository in a compact, one-line format
 
-`git log --oneline`
+2. `git commit --allow-empty -m "Empty commit"`
+    - Creates an empty commit with the message "Empty commit"
 
-Lists all commits in the repository in a compact, one-line format.
+3. `git commit --allow-empty --allow-empty-message -m ""`
+    - Creates an empty commit with an empty message. Creates an empty commit with an empty message. Useful for triggering CI pipelines and allowing for the creation of GitHub pull request
 
-## Create an Empty Commit
+4. `git reset --soft HEAD~1`
+    - Resets the current branch to the previous commit, keeping the changes in the staging area
 
-`git commit --allow-empty -m "Empty commit"`
+5. `git fetch --prune`
+    - Fetches from remote and removes stale remote-tracking refs (`origin/*` bookmarks) for branches deleted on the remote — local branches are never touched
+    - Prune without fetching: `git remote prune origin`
+    - After pruning, `git branch -vv` marks local branches whose remote is gone with `[origin/...: gone]` — usually means the PR was merged (squash merges hide this from `git branch -d`, so `-D` is needed)
+    - Make every fetch/pull auto-prune: `git config --global fetch.prune true`
 
-Creates an empty commit with the message "Empty commit".
+6. `git diff main..HEAD`
+    - See diff for changes on your branch but not on main (one way)
 
-## Create an Empty Commit with an Empty Message
+7. `git diff main...HEAD`  
+    - See diff for change between your brnach and main (two way)
 
-`git commit --allow-empty --allow-empty-message -m ""`
+8. `git difftool --staged --tool=code`
+    - Opens the staged changes with the `code` diff tool 
+    - Needs to be setup with:
+        - `git config --global difftool.code.cmd 'code --wait --diff --reuse-window "$LOCAL" "$REMOTE"'` (Set code as a diff tool)
+        - `git config --global diff.tool code` (Set code as the default diff tool)
+        - `git config --global difftool.prompt false` (Disable the per file diff permission) 
 
-Useful for triggering CI pipelines and allowing for the creation of GitHub pull requests.
+9. `git add --intent-to-add .` (or `git add -N .`)
+    - Marks untracked files as known to git without staging
+    - By default, untracked files don't show up in `git diff`
 
-## Undo the Last Commit, Keeping Changes Staged
-
-`git reset --soft HEAD~1`
-
-Resets the current branch to the previous commit, keeping the changes in the staging area.
-
-## Remove Stale Remote-Tracking Refs
-
-`git fetch --prune`
-
-Fetches from remote and removes stale remote-tracking refs (`origin/*` bookmarks) for branches deleted on the remote. Local branches are never touched. To prune without fetching, use `git remote prune origin`.
-
-After pruning, `git branch -vv` marks local branches whose remote is gone with `[origin/...: gone]`. This usually means the PR was merged. Squash merges hide this from `git branch -d`, so `-D` is needed.
-
-To make every fetch and pull auto-prune:
-
-```bash
-git config --global fetch.prune true
-```
-
-## See Diff for Changes on Your Branch but Not on Main (One Way)
-
-`git diff main..HEAD`
-
-## See Diff for Changes Between Your Branch and Main (Two Way)
-
-`git diff main...HEAD`
-
-## Open Staged Changes in the VS Code Diff Tool
-
-`git difftool --staged --tool=code`
-
-Needs to be set up with:
-
-```bash
-git config --global difftool.code.cmd 'code --wait --diff --reuse-window "$LOCAL" "$REMOTE"' # Set code as a diff tool
-git config --global diff.tool code             # Set code as the default diff tool
-git config --global difftool.prompt false      # Disable the per file diff permission
-```
-
-## Mark Untracked Files as Known to Git Without Staging
-
-`git add --intent-to-add .` (or `git add -N .`)
-
-By default, untracked files don't show up in `git diff`.
-
-## List Unpushed Commits
-
-`git log @{u}..HEAD --oneline`
-
-Lists commits on the current branch that aren't on its upstream (`@{u}`). Branch-agnostic, so it works on any branch without hardcoding `main`.
-
-`git cherry -v` is an alternative that also detects patch-equivalent commits (`+` = unpushed, `-` = already upstream in some form).
+10. `git log @{u}..HEAD --oneline`
+    - Lists unpushed commits: commits on the current branch that aren't on its upstream (`@{u}`)
+    - Branch-agnostic — works on any branch without hardcoding `main`
+    - Alternative: `git cherry -v` also detects patch-equivalent commits (`+` = unpushed, `-` = already upstream in some form)


### PR DESCRIPTION
Two additions to `website/notes/git.md`, both from a real cleanup session:

**Tightened #5 (`git fetch --prune`)** — the old description said it removes "branches deleted on the remote"; it actually removes stale *remote-tracking refs* (`origin/*` bookmarks), never local branches. Added:
- the prune-only variant `git remote prune origin`
- the `[origin/...: gone]` marker in `git branch -vv` as the tell that a local branch's PR merged and it's deletable
- why squash merges make `git branch -d` refuse (ancestry check can't see the squash commit), requiring `-D`
- `git config --global fetch.prune true` to auto-prune on every fetch

**New #10 (`git log @{u}..HEAD --oneline`)** — lists unpushed commits, branch-agnostic. Follow-up from a May session where this was picked over `git cherry -v` (still mentioned as the patch-equivalence alternative).

Context: found 15 stale `origin/*` refs in the workbench repo from auto-deleted PR branches, plus a local branch that looked unmerged but was squash-merged as PR #22 — verified by diffing the branch tip against the squash commit (identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)