### PR TITLE
Add four channels to interesting YouTube channels

### DIFF
--- a/website/_data/interesting-youtube-channels.yml
+++ b/website/_data/interesting-youtube-channels.yml
@@ -254,3 +254,11 @@
       url: https://www.youtube.com/watch?v=Syef-sWQu9k
     - title: "Well, Someone Had to Explain the Liar's Dice Scene In Pirates of the Caribbean: Dead Man's Chest"
       url: https://www.youtube.com/watch?v=T44LuxdH0iw
+- channel_name: "Siobhan Brier Aguilar"
+  channel_url: https://www.youtube.com/@SiobhanBrierAguilar
+  note: ""
+  display_on_page: true
+  reviewed_for_display_on_page: false
+  videos:
+    - title: 'The "Open Marriage" to Divorce Pipeline | A Review of Two Articles'
+      url: https://www.youtube.com/watch?v=Em0ukXd_ZbE&t=2462s

--- a/website/_data/interesting-youtube-channels.yml
+++ b/website/_data/interesting-youtube-channels.yml
@@ -262,3 +262,17 @@
   videos:
     - title: 'The "Open Marriage" to Divorce Pipeline | A Review of Two Articles'
       url: https://www.youtube.com/watch?v=Em0ukXd_ZbE&t=2462s
+- channel_name: "University of Virginia School of Law"
+  channel_url: https://www.youtube.com/@uvalaw
+  note: ""
+  display_on_page: true
+  reviewed_for_display_on_page: false
+  videos:
+    - title: 'Managing Client Relationships as an Investment Banker, Lawyer or Consultant'
+      url: https://www.youtube.com/watch?v=z8kqCIxXTEw
+    - title: '"Are You Destined to Deal?" With Goldman Sachs Managing Director Jim Donovan'
+      url: https://www.youtube.com/watch?v=RpUJfW4WTKw
+    - title: '"Secrets to Optimal Client Service," With Jim Donovan'
+      url: https://www.youtube.com/watch?v=hJbwyN4ZoCg&t=30s
+    - title: '"The Making of an Investment Banker," With Jim Donovan'
+      url: https://www.youtube.com/watch?v=3Pk8EmyK7kw

--- a/website/_data/interesting-youtube-channels.yml
+++ b/website/_data/interesting-youtube-channels.yml
@@ -276,3 +276,8 @@
       url: https://www.youtube.com/watch?v=hJbwyN4ZoCg&t=30s
     - title: '"The Making of an Investment Banker," With Jim Donovan'
       url: https://www.youtube.com/watch?v=3Pk8EmyK7kw
+- channel_name: "Jordan has no life"
+  channel_url: https://www.youtube.com/@jordanhasnolife5163
+  note: ""
+  display_on_page: true
+  reviewed_for_display_on_page: false

--- a/website/_data/interesting-youtube-channels.yml
+++ b/website/_data/interesting-youtube-channels.yml
@@ -281,3 +281,8 @@
   note: ""
   display_on_page: true
   reviewed_for_display_on_page: false
+- channel_name: "The PrimeTime"
+  channel_url: https://www.youtube.com/@ThePrimeTimeagen
+  note: ""
+  display_on_page: true
+  reviewed_for_display_on_page: false


### PR DESCRIPTION
Adds four channels to `interesting-youtube-channels.yml`:

1. [Siobhan Brier Aguilar](https://www.youtube.com/@SiobhanBrierAguilar) — with [The "Open Marriage" to Divorce Pipeline | A Review of Two Articles](https://www.youtube.com/watch?v=Em0ukXd_ZbE&t=2462s) (timestamped)
2. [University of Virginia School of Law](https://www.youtube.com/@uvalaw) — with all four Jim Donovan talks (titles verified via YouTube oEmbed): Managing Client Relationships (2015), "Are You Destined to Deal?" (2016), "Secrets to Optimal Client Service" (2022), "The Making of an Investment Banker" (2023)
3. [Jordan has no life](https://www.youtube.com/@jordanhasnolife5163)
4. [The PrimeTime](https://www.youtube.com/@ThePrimeTimeagen)

Also fixes the missing trailing newline on the previously-last entry. YAML parse-validated (37 channels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)