### PR TITLE
Honor display_on_page on the interesting YouTube channels page

### DIFF
--- a/website/interesting-youtube-channels.md
+++ b/website/interesting-youtube-channels.md
@@ -7,6 +7,7 @@ title: Interesting YouTube Channels
 
 <ul style="margin-bottom: 0;">
 {%- for channel in site.data.interesting-youtube-channels -%}
+{%- if channel.display_on_page -%}
 <li style="margin: 0;">
   <a href="{{ channel.channel_url }}">{{ channel.channel_name }}</a>
   {%- if channel.videos -%}
@@ -17,6 +18,7 @@ title: Interesting YouTube Channels
   </ul>
   {%- endif -%}
 </li>
+{%- endif -%}
 {%- endfor -%}
 </ul>
 
@@ -24,6 +26,8 @@ title: Interesting YouTube Channels
 
 <ul style="margin-bottom: 0;">
 {%- for video in site.data.interesting-youtube-videos -%}
+{%- if video.display_on_page -%}
 <li style="margin: 0;"><a href="{{ video.video_url }}">{{ video.video_title }}</a> by <a href="{{ video.channel_url }}">{{ video.channel_name }}</a></li>
+{%- endif -%}
 {%- endfor -%}
 </ul>


### PR DESCRIPTION
The `display_on_page` field exists on all 33+ entries in `interesting-youtube-channels.yml` and `interesting-youtube-videos.yml` but the template never checked it — every entry rendered unconditionally. This wires the flag into both loops (Channels and Videos sections).

**Verified:**
- With all entries `true` (current state), rendered HTML is **byte-identical** before/after — zero visible change on merge
- Flipping one entry to `false` in a test build removed exactly that entry from the page

`reviewed_for_display_on_page` remains metadata-only (never `true` anywhere, still unread) — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)