### PR TITLE
Add Ryan Holiday to interesting YouTube channels

### DIFF
--- a/website/_data/interesting-youtube-channels.yml
+++ b/website/_data/interesting-youtube-channels.yml
@@ -286,3 +286,8 @@
   note: ""
   display_on_page: true
   reviewed_for_display_on_page: false
+- channel_name: "Ryan Holiday"
+  channel_url: https://www.youtube.com/@RyanHolidayOfficial
+  note: ""
+  display_on_page: true
+  reviewed_for_display_on_page: false


### PR DESCRIPTION
Adds [Ryan Holiday](https://www.youtube.com/@RyanHolidayOfficial) (name per the channel's og:title). Not previously in the list. YAML parse-validated: 38 channels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)