### PR TITLE
Loosen Ruby pin to ~> 3.2.0

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.2.2"
+ruby "~> 3.2.0"
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the


### PR DESCRIPTION
The claude-box dev server runs Ubuntu's Ruby 3.2.3; the exact `3.2.2` pin (rbenv's version on the Mac) made `bundle install` fail there. `~> 3.2.0` accepts any 3.2.x patch release on both machines while still flagging a real minor/major version jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)