### PR TITLE
Fix CI Ruby version extraction for constraint-style Gemfile pins

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -18,7 +18,9 @@ jobs:
           key: ${{ runner.os }}-gem-${{ hashFiles('website/Gemfile.lock') }}
       
       - name: Get Ruby version from Gemfile
-        run: echo "RUBY_VERSION=$(grep -oP "(?<=ruby \").*(?=\")" website/Gemfile)" >> $GITHUB_ENV
+        # The Gemfile may hold a constraint like ~> 3.2.0; setup-ruby only
+        # accepts a version, so reduce to major.minor (= latest patch of it).
+        run: echo "RUBY_VERSION=$(grep -oP '(?<=ruby ")[^"]*' website/Gemfile | grep -oP '\d+\.\d+' | head -1)" >> $GITHUB_ENV
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
PR #566 changed the Gemfile's pin to `~> 3.2.0`, and the workflow's grep passes that string verbatim to `ruby/setup-ruby`, which only accepts plain versions — every PR build now fails at *Set up Ruby* with `Unknown engine ~> 3.2.0`. This distills whatever the Gemfile says down to `major.minor` (currently `3.2`), which setup-ruby resolves to the latest matching patch release — the same semantics the Gemfile constraint expresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)