### PR TITLE
Simplify Jekyll workflow: let setup-ruby own version and gem caching

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -14,8 +14,6 @@ jobs:
       - name: Set up Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
-          # Ruby version comes from website/.ruby-version;
-          # bundler-cache installs the gems and caches them.
           bundler-cache: true
           working-directory: './website'
 

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -10,30 +10,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v6
-        with:
-          path: website/vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('website/Gemfile.lock') }}
-      
-      - name: Get Ruby version from Gemfile
-        # The Gemfile may hold a constraint like ~> 3.2.0; setup-ruby only
-        # accepts a version, so reduce to major.minor (= latest patch of it).
-        run: echo "RUBY_VERSION=$(grep -oP '(?<=ruby ")[^"]*' website/Gemfile | grep -oP '\d+\.\d+' | head -1)" >> $GITHUB_ENV
 
-      - name: Set up Ruby
+      - name: Set up Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.RUBY_VERSION }}
+          # Ruby version comes from website/.ruby-version;
+          # bundler-cache installs the gems and caches them.
           bundler-cache: true
           working-directory: './website'
 
-      - name: Get dependencies if cache miss
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          cd website
-          bundle install --jobs 4 --retry 3 --path vendor/bundle
       - name: Build site and check for warnings or errors
         run: |
           cd website


### PR DESCRIPTION
Cleanup of the CI workflow, 41 → 26 lines, five steps → three:

- **Ruby version**: `setup-ruby` reads `website/.ruby-version` (already in the repo — it's what rbenv uses locally) when no `ruby-version` input is given, so the grep-the-Gemfile env-var step is gone. The Gemfile's `~> 3.2.0` constraint remains the runtime arbiter everywhere.
- **Caching**: `bundler-cache: true` already runs `bundle install` and caches vendored gems keyed on the lockfile, so the manual `actions/cache` block and the cache-miss install step were redundant.
- `ruby/setup-ruby@v1` is already the newest major — v1 is its rolling tag (currently v1.321.0); there is no v2 to bump to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)