### PR TITLE
Add from json --objects and table --expand to Nushell notes

### DIFF
--- a/website/notes/nu.md
+++ b/website/notes/nu.md
@@ -7,17 +7,21 @@ title: Nushell
 
 I learned about [Nushell](https://www.nushell.sh/) from this video from [Tom Delalande](https://www.youtube.com/watch?v=K_yK-tEeGDA). I was blown away by how good it was at interrogating data.
 
-Useful commands
+## Notes:
+- [from json --objects](https://www.nushell.sh/commands/docs/from_json.html) parses JSONL, treating each line as a separate JSON object (e.g. `open data.json | from json --objects`)
+- [table --expand](https://www.nushell.sh/commands/docs/table.html) renders nested records inline instead of collapsing them to `{record 1 field}`
+- [explore](https://www.nushell.sh/book/explore.html) is a pager like [less](https://en.wikipedia.org/wiki/Less_(Unix)) but for tables in nushell
+
+
+## Useful commands
 - sort-by
 - reverse
 - where
 - first
 - get
-- [from json --objects](https://www.nushell.sh/commands/docs/from_json.html) parses JSONL, treating each line as a separate JSON object (e.g. `open data.jsonl | from json --objects`)
-- [table --expand](https://www.nushell.sh/commands/docs/table.html) renders nested records inline instead of collapsing them to `{record 1 field}`
-- [explore](https://www.nushell.sh/book/explore.html) is a pager like [less](https://en.wikipedia.org/wiki/Less_(Unix)) but for tables in nushell
 
-References:
+
+## References:
 - [Nushell Book](https://www.nushell.sh/book/)
 - [Command Reference](http://nushell.sh/commands/)
 - [Quick Tour — Nushell](https://www.nushell.sh/book/quick_tour.html)

--- a/website/notes/nu.md
+++ b/website/notes/nu.md
@@ -13,6 +13,8 @@ Useful commands
 - where
 - first
 - get
+- [from json --objects](https://www.nushell.sh/commands/docs/from_json.html) parses JSONL, treating each line as a separate JSON object (e.g. `open data.jsonl | from json --objects`)
+- [table --expand](https://www.nushell.sh/commands/docs/table.html) renders nested records inline instead of collapsing them to `{record 1 field}`
 - [explore](https://www.nushell.sh/book/explore.html) is a pager like [less](https://en.wikipedia.org/wiki/Less_(Unix)) but for tables in nushell
 
 References:


### PR DESCRIPTION
Adds two commands to the Nushell notes' useful-commands list, learned while poking at a JSONL file:

- `from json --objects` — parses JSONL, treating each line as a separate JSON object (e.g. `open data.jsonl | from json --objects`)
- `table --expand` — renders nested records inline instead of collapsing them to `{record 1 field}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)